### PR TITLE
Adds a call to the package_tool utility, so the wrapper installs the required packages.

### DIFF
--- a/numa_streams/numa_streams.json
+++ b/numa_streams/numa_streams.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
         "amzn": [
+            "git",
             "gcc",
             "bc",
             "zip",
@@ -14,6 +15,7 @@
             "libomp"
         ],
         "rhel": [
+            "git",
             "gcc",
             "bc",
             "perf",
@@ -28,6 +30,7 @@
             "libomp"
         ],
         "sles": [
+            "git",
             "gcc",
             "make",
             "bc",
@@ -39,11 +42,12 @@
             "numactl"
         ],
         "ubuntu": [
+            "git",
             "bc",
             "zip",
             "unzip",
             "numactl",
-	    "libnuma-dev",
+            "libnuma-dev",
             "g++",
             "autoconf",
             "hwloc",

--- a/numa_streams/numa_streams.json
+++ b/numa_streams/numa_streams.json
@@ -35,7 +35,6 @@
             "make",
             "bc",
             "perf",
-            "git",
             "unzip",
             "zip",
             "libnuma1",

--- a/numa_streams/numa_streams.json
+++ b/numa_streams/numa_streams.json
@@ -1,0 +1,55 @@
+{
+    "dependencies": {
+        "amzn": [
+            "gcc",
+            "bc",
+            "zip",
+            "unzip",
+            "numactl",
+            "wget",
+            "gcc-c++",
+            "autoconf",
+            "hwloc",
+            "hwloc-gui",
+            "libomp"
+        ],
+        "rhel": [
+            "gcc",
+            "bc",
+            "perf",
+            "zip",
+            "unzip",
+            "numactl",
+            "wget",
+            "gcc-c++",
+            "autoconf",
+            "hwloc",
+            "hwloc-gui",
+            "libomp"
+        ],
+        "sles": [
+            "gcc",
+            "make",
+            "bc",
+            "perf",
+            "git",
+            "unzip",
+            "zip",
+            "libnuma1",
+            "numactl"
+        ],
+        "ubuntu": [
+            "bc",
+            "zip",
+            "unzip",
+            "numactl",
+	    "libnuma-dev",
+            "g++",
+            "autoconf",
+            "hwloc",
+            "libomp5-20"
+        ],
+        "pip": [
+        ]
+    }
+}

--- a/numa_streams/numa_streams_extra/run_numa_stream
+++ b/numa_streams/numa_streams_extra/run_numa_stream
@@ -206,7 +206,6 @@ setup_sizing()
 
 install_numa_streams()
 {
-	dnf install wget gcc gcc-c++ autoconf hwloc hwloc-gui libomp  -y
 	git clone https://github.com/jemalloc/jemalloc.git
 	pushd jemalloc > /dev/null
 	./autogen.sh

--- a/numa_streams/numa_streams_run
+++ b/numa_streams/numa_streams_run
@@ -367,6 +367,12 @@ if [ ! -f "/tmp/${test_name}.out" ]; then
 	exit $?
 fi
 
+${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/numa_streams.json --no_packages $to_no_pkg_install
+if [[ $? -ne 0 ]]; then
+	echo Packaging installed failed.
+	exit 1
+fi
+
 #
 # Define user options
 #

--- a/numa_streams/numa_streams_run
+++ b/numa_streams/numa_streams_run
@@ -369,7 +369,7 @@ fi
 
 ${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/numa_streams.json --no_packages $to_no_pkg_install
 if [[ $? -ne 0 ]]; then
-	echo Packaging installed failed.
+	echo Error: Package installation using ${TOOLS_BIN}/package_tool was unsuccessful.
 	exit 1
 fi
 


### PR DESCRIPTION
# Description
Adds a call to the package_tool utility, so the wrapper installs the required packages.

# Before/After Comparison
Before: Wrapper depended on the user or Zathras to install the packages for it.
After: The wrapper will now install the packages it requires to run

# Clerical Stuff
This closes #9 

Relates to JIRA: RPOPC-665

# Testing
Updated and tested on Amazon, RHEL, SUSE and Ubuntu.
